### PR TITLE
Ensure no overlapping updates and avoid renovate

### DIFF
--- a/copier.yaml
+++ b/copier.yaml
@@ -50,6 +50,7 @@ _exclude:
   - "*.py[co]"
   - "~*"
   - copier.yaml
+  - renovate.json
   - tests/test_template.py
   - .github/workflows/test-template.yml
 

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "schedule": ["* * 1 * *"],
   "enabledManagers": ["custom.regex"],
+  "ignorePaths": [
+    ".github/workflows/*.yml",
+    ".github/workflows/*.yaml"
+  ],
   "customManagers": [
     {
       "customType": "regex",

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -50,6 +50,7 @@ def test_template(tmp_path: Path) -> None:
     # Assert a file from the template was created
     assert (dst_path / "src/demo_project/main.py").exists()
     assert not (dst_path / ".git").exists()
+    assert not (dst_path / "renovate.json").exists()
 
     # Run pytest from the copied template
     subprocess.run(["uv", "run", "pytest"], cwd=dst_path, check=True)
@@ -77,5 +78,6 @@ def test_template_preserves_existing_git_repo(tmp_path: Path) -> None:
     )
 
     assert (dst_path / "src/demo_project/main.py").exists()
+    assert not (dst_path / "renovate.json").exists()
     assert _git("rev-parse", "--is-inside-work-tree", cwd=dst_path) == "true"
     assert _git("rev-parse", "HEAD", cwd=dst_path) == original_head


### PR DESCRIPTION
Ensures no overlapping updates between dependabot and renovate. Also avoids sending renovate config in copier implementations.
